### PR TITLE
Add quiesce functionality to enable zero-downtime deploys

### DIFF
--- a/src/include/microhttpd.h
+++ b/src/include/microhttpd.h
@@ -1108,6 +1108,17 @@ MHD_stop_daemon (struct MHD_Daemon *daemon);
 
 
 /**
+ * Shutdown http daemon listening sockets.
+ *
+ * Allows clients to continue processing, but stops accepting connections
+ *
+ * @param daemon daemon to stop
+ */
+void
+MHD_quiesce_daemon (struct MHD_Daemon *daemon);
+
+
+/**
  * Add another client connection to the set of connections 
  * managed by MHD.  This API is usually not needed (since
  * MHD will accept inbound connections on the server socket).


### PR DESCRIPTION
This lets us fork/exec new code, have the original code allow the existing clients to finish but block new connections, while the new code starts accepting connections.

We still need to write the signal handling and fork/exec code into the daemon, but this provides enough functionality that it's possible to do zero-downtime deploys unicorn style.

cc @github/systems
